### PR TITLE
Revamping Installer.py for Mac

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -33,26 +33,26 @@ class dep_installer():
                 print "\n[!]  Error installing Android tools"
 
         elif platform == "darwin":
-            
+
                 print "\n[+]  Installing necessary tools on MAC"
             try:
-                os.system('sudo apt-get install toilet')
+                os.system('sudo brew install toilet')
                 print "\n[+]  Installation of dependencies complete"
             except OSError as ose:
                 print "\n[!]  Error installing dependency"
 
             print "\n[+]  Installing ARM dependencies"
             try:
-                os.system('sudo apt-get install libc6-armel-cross libc6-dev-armel-cross')
-                os.system('sudo apt-get install binutils-arm-linux-gnueabi')
-                os.system('sudo apt-get install libncurses5-dev')
+                os.system('sudo brew install libc6-armel-cross libc6-dev-armel-cross')
+                os.system('sudo brew install binutils-arm-linux-gnueabi')
+                os.system('sudo brew install libncurses5-dev')
                 print "\n[+]  Installation of ARM tools complete"
             except OSError as ose:
                 print "\n[!]  Error installing ARM dependencies"
 
             print "\n[+]  Installing Android debug tools "
             try:
-                os.system('sudo apt-get install android-tools-adb')
+                os.system('sudo brew install android-tools-adb')
                 print "\n[+]  Installation of Android tools complete"
             except OSError as ose:
                 print "\n[!]  Error installing Android tools"

--- a/installer.py
+++ b/installer.py
@@ -45,14 +45,14 @@ class dep_installer():
             try:
                 os.system('brew install libc6-armel-cross libc6-dev-armel-cross')
                 os.system('brew install binutils')
-                os.system('brew install libncurses5-dev')
+                os.system('brew install ncurses')
                 print "\n[+]  Installation of ARM tools complete"
             except OSError as ose:
                 print "\n[!]  Error installing ARM dependencies"
 
             print "\n[+]  Installing Android debug tools "
             try:
-                os.system('brew brew cask install android-platform-tools')
+                os.system('brew cask install android-platform-tools')
                 print "\n[+]  Installation of Android tools complete"
             except OSError as ose:
                 print "\n[!]  Error installing Android tools"

--- a/installer.py
+++ b/installer.py
@@ -52,7 +52,7 @@ class dep_installer():
 
             print "\n[+]  Installing Android debug tools "
             try:
-                os.system('brew install android-tools-adb')
+                os.system('brew brew cask install android-platform-tools')
                 print "\n[+]  Installation of Android tools complete"
             except OSError as ose:
                 print "\n[!]  Error installing Android tools"

--- a/installer.py
+++ b/installer.py
@@ -1,6 +1,7 @@
 # !/usr/bin/env python
 
 import os
+from sys import platform
 
 
 class dep_installer():

--- a/installer.py
+++ b/installer.py
@@ -62,6 +62,7 @@ class dep_installer():
                 print "\n[+]  Installing necessary tools on Windows"
 
 
+
 def main():
     dep = dep_installer()
     dep.ins()

--- a/installer.py
+++ b/installer.py
@@ -34,7 +34,7 @@ class dep_installer():
 
         elif platform == "darwin":
 
-                print "\n[+]  Installing necessary tools on MAC"
+            print "\n[+]  Installing necessary tools on MAC"
             try:
                 os.system('sudo brew install toilet')
                 print "\n[+]  Installation of dependencies complete"
@@ -58,7 +58,9 @@ class dep_installer():
                 print "\n[!]  Error installing Android tools"
 
         elif platform == "win32":
-                #Windows installation here
+                #Windows
+                print "\n[+]  Installing necessary tools on Windows"
+
 
 def main():
     dep = dep_installer()

--- a/installer.py
+++ b/installer.py
@@ -36,23 +36,23 @@ class dep_installer():
 
             print "\n[+]  Installing necessary tools on MAC"
             try:
-                os.system('sudo brew install toilet')
+                os.system('brew install toilet')
                 print "\n[+]  Installation of dependencies complete"
             except OSError as ose:
                 print "\n[!]  Error installing dependency"
 
             print "\n[+]  Installing ARM dependencies"
             try:
-                os.system('sudo brew install libc6-armel-cross libc6-dev-armel-cross')
-                os.system('sudo brew install binutils-arm-linux-gnueabi')
-                os.system('sudo brew install libncurses5-dev')
+                os.system('brew install libc6-armel-cross libc6-dev-armel-cross')
+                os.system('brew install binutils-arm-linux-gnueabi')
+                os.system('brew install libncurses5-dev')
                 print "\n[+]  Installation of ARM tools complete"
             except OSError as ose:
                 print "\n[!]  Error installing ARM dependencies"
 
             print "\n[+]  Installing Android debug tools "
             try:
-                os.system('sudo brew install android-tools-adb')
+                os.system('brew install android-tools-adb')
                 print "\n[+]  Installation of Android tools complete"
             except OSError as ose:
                 print "\n[!]  Error installing Android tools"

--- a/installer.py
+++ b/installer.py
@@ -43,7 +43,8 @@ class dep_installer():
 
             print "\n[+]  Installing ARM dependencies"
             try:
-                os.system('brew install libc6-armel-cross libc6-dev-armel-cross')
+                os.system('brew tap osx-cross/arm')
+                os.system('brew install arm-gcc-bin')
                 os.system('brew install binutils')
                 os.system('brew install ncurses')
                 print "\n[+]  Installation of ARM tools complete"
@@ -58,7 +59,7 @@ class dep_installer():
                 print "\n[!]  Error installing Android tools"
 
         elif platform == "win32":
-                #Windows
+                #TO-DO Windows
                 print "\n[+]  Installing necessary tools on Windows"
 
 

--- a/installer.py
+++ b/installer.py
@@ -6,33 +6,59 @@ from sys import platform
 
 class dep_installer():
 
-    def __init__(self):
-        pass
-
     def ins(self):
-        print "\n[+]  Installing necessary tools "
-        try:
-            os.system('sudo apt-get install toilet')
-            print "\n[+]  Installation of dependencies complete"
-        except OSError as ose:
-            print "\n[!]  Error installing dependency"
+        if platform == "linux" or platform == "linux2":
+                # linux
+            print "\n[+]  Installing necessary tools on Linux"
+            try:
+                os.system('sudo apt-get install toilet')
+                print "\n[+]  Installation of dependencies complete"
+            except OSError as ose:
+                print "\n[!]  Error installing dependency"
 
-        print "\n[+]  Installing ARM dependencies"
-        try:
-            os.system('sudo apt-get install libc6-armel-cross libc6-dev-armel-cross')
-            os.system('sudo apt-get install binutils-arm-linux-gnueabi')
-            os.system('sudo apt-get install libncurses5-dev')
-            print "\n[+]  Installation of ARM tools complete"
-        except OSError as ose:
-            print "\n[!]  Error installing ARM dependencies"
+            print "\n[+]  Installing ARM dependencies"
+            try:
+                os.system('sudo apt-get install libc6-armel-cross libc6-dev-armel-cross')
+                os.system('sudo apt-get install binutils-arm-linux-gnueabi')
+                os.system('sudo apt-get install libncurses5-dev')
+                print "\n[+]  Installation of ARM tools complete"
+            except OSError as ose:
+                print "\n[!]  Error installing ARM dependencies"
 
-        print "\n[+]  Installing Android debug tools "
-        try:
-            os.system('sudo apt-get install android-tools-adb')
-            print "\n[+]  Installation of Android tools complete"
-        except OSError as ose:
-            print "\n[!]  Error installing Android tools"
+            print "\n[+]  Installing Android debug tools "
+            try:
+                os.system('sudo apt-get install android-tools-adb')
+                print "\n[+]  Installation of Android tools complete"
+            except OSError as ose:
+                print "\n[!]  Error installing Android tools"
 
+        elif platform == "darwin":
+            
+                print "\n[+]  Installing necessary tools on MAC"
+            try:
+                os.system('sudo apt-get install toilet')
+                print "\n[+]  Installation of dependencies complete"
+            except OSError as ose:
+                print "\n[!]  Error installing dependency"
+
+            print "\n[+]  Installing ARM dependencies"
+            try:
+                os.system('sudo apt-get install libc6-armel-cross libc6-dev-armel-cross')
+                os.system('sudo apt-get install binutils-arm-linux-gnueabi')
+                os.system('sudo apt-get install libncurses5-dev')
+                print "\n[+]  Installation of ARM tools complete"
+            except OSError as ose:
+                print "\n[!]  Error installing ARM dependencies"
+
+            print "\n[+]  Installing Android debug tools "
+            try:
+                os.system('sudo apt-get install android-tools-adb')
+                print "\n[+]  Installation of Android tools complete"
+            except OSError as ose:
+                print "\n[!]  Error installing Android tools"
+
+        elif platform == "win32":
+                #Windows installation here
 
 def main():
     dep = dep_installer()

--- a/installer.py
+++ b/installer.py
@@ -44,7 +44,7 @@ class dep_installer():
             print "\n[+]  Installing ARM dependencies"
             try:
                 os.system('brew install libc6-armel-cross libc6-dev-armel-cross')
-                os.system('brew install binutils-arm-linux-gnueabi')
+                os.system('brew install binutils')
                 os.system('brew install libncurses5-dev')
                 print "\n[+]  Installation of ARM tools complete"
             except OSError as ose:


### PR DESCRIPTION
# Installer.py fix for Mac

* Revamped `installer.py `for Mac 
* Removed `sudo` mode for Mac as homebrew does not support `sudo` mode installation.
* Mac Alternative for Android debug tools:
  * `android-tools-adb`
* ARM dependencies:
  * `arm-gcc-bin`
  * `binutils`
  * `ncurses`
* Fixes #4 

## TO-DO
* Installation candidate for `win32`