### PR TITLE
fix to #31 and #32

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -10,7 +10,7 @@ class DepInstaller:
 
     def __init__(self):
         self.apt_tools = ['python-pip', 'python3-setuptools', 'python3-pip', 'android-tools-adb', 'toilet']
-        self.pip_tools = ['PrettyTable', 'requests', 'progressbar2', 'colorama', 'urllib3', 'Jinja2', 'r2pipe', 'smalisca']
+        self.pip_tools = ['PrettyTable', 'requests', 'progressbar2', 'colorama', 'urllib3', 'Jinja2', 'r2pipe', 'smalisca', 'cement==2.10.12']
         self.uninstalled = []
 
     def ins(self):

--- a/installer.py
+++ b/installer.py
@@ -10,7 +10,7 @@ class DepInstaller:
 
     def __init__(self):
         self.apt_tools = ['python-pip', 'python3-setuptools', 'python3-pip', 'android-tools-adb', 'toilet']
-        self.pip_tools = ['PrettyTable', 'requests', 'progressbar2', 'colorama', 'urllib3', 'Jinja2', 'r2pipe']
+        self.pip_tools = ['PrettyTable', 'requests', 'progressbar2', 'colorama', 'urllib3', 'Jinja2', 'r2pipe', 'smalisca']
         self.uninstalled = []
 
     def ins(self):


### PR DESCRIPTION
### Changes Proposed
fix to https://github.com/abhi-r3v0/Adhrit/issues/31 and https://github.com/abhi-r3v0/Adhrit/issues/32

### Explanation of Changes
 - add smalisca to installer.py
 - smalisca default comes with cement 3.x ,  throws Error 

`AttributeError: module 'cement.core.controller' has no attribute 'CementBaseController'`
 - hence cement vesion set to 2.10.12
